### PR TITLE
Make `react-visibility-sensor` support server rendering.

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -2,6 +2,12 @@
 
 var React = require('react');
 
+var containmentPropType = React.PropTypes.any;
+
+if (typeof window !== 'undefined') {
+  containmentPropType = React.PropTypes.instanceOf(Element);
+}
+
 module.exports = React.createClass({
   displayName: 'VisibilitySensor',
 
@@ -9,7 +15,7 @@ module.exports = React.createClass({
     onChange: React.PropTypes.func.isRequired,
     active: React.PropTypes.bool,
     delay: React.PropTypes.number,
-    containment: React.PropTypes.instanceOf(Element),
+    containment: containmentPropType,
     children: React.PropTypes.element
   },
 


### PR DESCRIPTION
Obviously, using Element in PropTypes breaks server rendering.

Use an `if` to overcome that. Better solution is highly appreciated.