### PR TITLE
Upgrade example to work with React 0.14

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -1,8 +1,8 @@
-/** @jsx React.DOM */
 'use strict';
 
 var React = require('react');
-var VisibilitySensor = React.createFactory(require('../'));
+var ReactDOM = require('react-dom')
+var VisibilitySensor = require('../');
 
 var Example = React.createClass({
   getInitialState: function () {
@@ -31,10 +31,10 @@ var Example = React.createClass({
   }
 });
 
-React.render(React.createElement(Example), document.getElementById('example'));
+ReactDOM.render(React.createElement(Example), document.getElementById('example'));
 
 var container = document.getElementById('example-container');
 var elem = container.querySelector('.inner');
 container.scrollTop = 320;
 container.scrollLeft = 320;
-React.render(React.createElement(Example, { containment: container }), elem);
+ReactDOM.render(React.createElement(Example, { containment: container }), elem);

--- a/package.json
+++ b/package.json
@@ -31,13 +31,6 @@
     "mocha": "^1.21.4",
     "reactify": "^1.1.1"
   },
-  "browserify": {
-    "transform": [
-      [
-        "reactify"
-      ]
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/joshwnj/react-visibility-sensor.git"


### PR DESCRIPTION
Example is upgraded, and I've also confirmed that everything works without the `transform` field in package.json so have removed that, as @mvila noted in #11 

@kof & @kompot do you see anything else that should be updated before we publish v3.0.0?