### PR TITLE
Mark partially visible when center is visible

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -117,13 +117,15 @@ module.exports = React.createClass({
     // check for partial visibility
     if (this.props.partialVisibility) {
       var partialVertical =
-          (rect.top >= containmentRect.top && rect.top <= containmentRect.bottom)
-          || (rect.bottom >= containmentRect.top && rect.bottom <= containmentRect.bottom)
-          || (rect.top <= containmentRect.top && rect.bottom >= containmentRect.bottom);
+          (rect.top >= containmentRect.top && rect.top <= containmentRect.bottom)           // Top is visible
+          || (rect.bottom >= containmentRect.top && rect.bottom <= containmentRect.bottom)  // Bottom is visible
+          || (rect.top <= containmentRect.top && rect.bottom >= containmentRect.bottom);    // Center is visible
+
 
       var partialHorizontal =
-          (rect.left >= containmentRect.left && rect.left <= containmentRect.right)
-          || (rect.right >= containmentRect.left && rect.right <= containmentRect.right);
+          (rect.left >= containmentRect.left && rect.left <= containmentRect.right)         // Left side is visible
+          || (rect.right >= containmentRect.left && rect.right <= containmentRect.right)    // Right side is visible
+          || (rect.left <= containmentRect.left && rect.right >= containmentRect.right);    // Center is visible
 
       var partialVisible = partialVertical && partialHorizontal;
 


### PR DESCRIPTION
This change marks an element as partially visible when just the center is visible, in addition to one of the sides being visible.

I've also added comments to make the code a bit easier to understand.

Right now, these two scenarios are marked as partially visible:

![artboard 1](https://cloud.githubusercontent.com/assets/1703323/16914628/5bbbeff8-4cf3-11e6-9e2d-cc11f3dc4f07.png)

![artboard 1 copy](https://cloud.githubusercontent.com/assets/1703323/16914631/61adc120-4cf3-11e6-923d-d2948bc87f0e.png)

And when this PR is merged, this will be marked as visible too:

![artboard 1 copy 2](https://cloud.githubusercontent.com/assets/1703323/16914649/79f4ed8a-4cf3-11e6-8491-5cb1495f5294.png)


Note: the logic to determine whether an element is vertically partially visible already works this way.