### PR TITLE
Added containmentPadding prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Props
 - `minTopValue`: (default `false`) consider element visible if only part of it is visible and a minimum amount of pixels could be set, so if at least 100px are in viewport, we mark element as visible.
 - `delay`: (default `1000`) integer, number of milliseconds between checking the element's position in relation the the window viewport. Making this number too low will have a negative impact on performance.
 - `containment`: (optional) element to use as a viewport when checking visibility. Default behaviour is to use the browser window as viewport.
+- `containmentPadding`: (default `0`) integer, padding to expand the containment / viewport. When offloading rich content for performance, this padding will allow you to expand the rendered region outside the visible region in order to maintain smooth scrolling. This padding does not require `containment` to be set, it will also default to the window as the viewport.
 - `delayedCall`: (default `false`) if is set to true, wont execute on page load ( prevents react apps triggering elements as visible before styles are loaded )
 
 Thanks

--- a/tests/visibility-sensor-spec.jsx
+++ b/tests/visibility-sensor-spec.jsx
@@ -90,6 +90,43 @@ describe('VisibilitySensor', function () {
     ReactDOM.render(element, node);
   });
 
+  it('should respect containmentPadding when provided', function (done) {
+    var callCount = 0;
+
+    var onChange = function (isVisible) {
+      switch (callCount) {
+        case 0:
+          callCount++;
+          assert.equal(isVisible, true, 'Component starts out visible');
+          ReactDOM.render(getElement({ left: -101 }), node);
+          break;
+        case 1:
+          callCount++;
+          assert.equal(isVisible, true, 'Component visible within padded containment');
+          ReactDOM.render(getElement({ left: -501 }), node);
+          break;
+        case 2:
+          assert.equal(isVisible, false, 'Component outside padded containment');
+          done();
+          break;
+      }
+    };
+
+    function getElement (style) {
+      style = style || {};
+      style.position = 'absolute';
+      style.width = 100;
+
+      return (
+        <VisibilitySensor delay={10} onChange={onChange} containmentPadding={500}>
+          <div style={style} />
+        </VisibilitySensor>
+      );
+    }
+
+    ReactDOM.render(getElement(), node);
+  })
+
   it('should not notify when deactivated', function (done) {
     var wasCallbackCalled = false;
     var onChange = function (isVisible) {

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -22,6 +22,7 @@ module.exports = React.createClass({
     delay: React.PropTypes.number,
     delayedCall: React.PropTypes.bool,
     containment: containmentPropType,
+    containmentPadding: React.PropTypes.number,
     children: React.PropTypes.element,
     minTopValue: React.PropTypes.number
   },
@@ -34,6 +35,7 @@ module.exports = React.createClass({
       delay: 1000,
       delayedCall: false,
       containment: null,
+      containmentPadding: 0,
       children: React.createElement('span')
     };
   },
@@ -100,6 +102,12 @@ module.exports = React.createClass({
         right: window.innerWidth || document.documentElement.clientWidth
       };
     }
+
+    // update containment bounds
+    containmentRect.top -= this.props.containmentPadding
+    containmentRect.left -= this.props.containmentPadding
+    containmentRect.bottom += this.props.containmentPadding
+    containmentRect.right += this.props.containmentPadding
 
     var visibilityRect = {
       top: rect.top >= containmentRect.top,


### PR DESCRIPTION
Added `containmentPadding` which allows content to render outside of the viewport/containment container to enable smooth scrolling. 

e.g. If you are using this utility to offload images and videos from the DOM when they are outside the viewport, you don't want them to flash back in when they are within visible bounds.