### PR TITLE
make it testable outside a browser.

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -6,7 +6,7 @@ var ReactDOM = require('react-dom');
 var containmentPropType = React.PropTypes.any;
 
 if (typeof window !== 'undefined') {
-  containmentPropType = React.PropTypes.instanceOf(Element);
+  containmentPropType = React.PropTypes.instanceOf(window.Element);
 }
 
 module.exports = React.createClass({


### PR DESCRIPTION
Accessing Element through window object allow to use jsdom for testing react component without having to use a real browser.