### PR TITLE
Changed default behaviour from intervalCheck to onScroll Listener.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+sudo: required
+dist: trusty
 language: node_js
 node_js:
-  - 0.12
+ - 0.12
+
+before_install:
+ - export CHROME_BIN=/usr/bin/google-chrome
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - sudo apt-get update
+ - sudo apt-get install -y libappindicator1 fonts-liberation
+ - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+ - sudo dpkg -i google-chrome*.deb

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Props
 - `active`: (default `true`) boolean flag for enabling / disabling the sensor.  When `active !== true` the sensor will not fire the `onChange` callback.
 - `partialVisibility`: (default `false`) consider element visible if only part of it is visible. Also possible values are - 'top', 'right', 'bottom', 'left' - in case it's needed to detect when one of these become visible explicitly.
 - `minTopValue`: (default `false`) consider element visible if only part of it is visible and a minimum amount of pixels could be set, so if at least 100px are in viewport, we mark element as visible.
-- `delay`: (default `1000`) integer, number of milliseconds between checking the element's position in relation the the window viewport. Making this number too low will have a negative impact on performance.
+- `intervalCheck`: (default `false`) the default usage of Visibility Sensor is to trigger a check on user scrolling, by checking this as true, it gives you the possibility to check if the element is in view even if it wasn't because of a user scroll
+- `intervalDelay`: (default `1000`) integer, number of milliseconds between checking the element's position in relation the the window viewport. Making this number too low will have a negative impact on performance.
+- `disableScrollCheck`: (default: `false`) by making this true, the scroll listener is disabled and the intervalCheck is enabled with or without the `intervalCheck` props being set.
+- `delay`: (default: `250`) is the debounce rate at which the check is triggered. Ex: 250ms after the user stopped scrolling.
 - `containment`: (optional) element to use as a viewport when checking visibility. Default behaviour is to use the browser window as viewport.
 - `delayedCall`: (default `false`) if is set to true, wont execute on page load ( prevents react apps triggering elements as visible before styles are loaded )
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,9 +49,15 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: [
-      process.env.TRAVIS === "true" ? 'PhantomJS' : 'Chrome'
+      process.env.TRAVIS === "true" ? 'Chrome_travis_ci' : 'Chrome'
     ],
 
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/tests/visibility-sensor-spec.jsx
+++ b/tests/visibility-sensor-spec.jsx
@@ -38,7 +38,33 @@ describe('VisibilitySensor', function () {
     };
 
     var element = (
-      <VisibilitySensor delay={10} onChange={onChange} />
+      <VisibilitySensor delay={10} onChange={onChange} intervalCheck />
+    );
+
+    ReactDOM.render(element, node);
+  });
+
+  it('should notify of changes to visibility when user scrolls', function (done) {
+    var firstTime = true;
+    var onChange = function (isVisible) {
+      // by default we expect the sensor to be visible
+      if (firstTime) {
+        firstTime = false;
+        assert.equal(isVisible, true, 'Component starts out visible');
+
+        window.scrollTo(0,1000);
+      }
+      // after moving the sensor it should be not visible anymore
+      else {
+        assert.equal(isVisible, false, 'Component has moved out of the visible viewport');
+        done();
+      }
+    };
+
+    var element = (
+      <div style={{height: '5000px'}}>
+        <VisibilitySensor delay={10} onChange={onChange} />
+      </div>
     );
 
     ReactDOM.render(element, node);
@@ -66,9 +92,10 @@ describe('VisibilitySensor', function () {
       }
     };
 
+    // set interval must be one in order for this to work
     function getElement(style) {
       return (
-        <VisibilitySensor delay={10} onChange={onChange}>
+        <VisibilitySensor delay={10} onChange={onChange} intervalCheck>
           <div style={style} />
         </VisibilitySensor>
       );
@@ -102,7 +129,7 @@ describe('VisibilitySensor', function () {
     }, 20);
 
     var element = (
-      <VisibilitySensor active={false} delay={1} onChange={onChange} />
+      <VisibilitySensor active={false} intervalCheck intervalDelay={1} onChange={onChange} />
     );
 
     ReactDOM.render(element, node);

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -86,7 +86,7 @@ module.exports = React.createClass({
   startWatching: function () {
     if (this.debounceCheck || this.interval) { return; }
 
-    if (this.props.intervalCheck) {
+    if (this.props.intervalCheck || this.props.disableScrollCheck) {
       this.interval = setInterval(this.check, this.props.intervalDelay);
     }
     if (!this.props.disableScrollCheck) {


### PR DESCRIPTION
Fixes #10 and #36 

Update: Changed main behaviour from intervalCheck to onScroll Listener
Update: Delay props now referrer to the scrolling debounce time until check is called
Update: IntervalCheck still exists but needs to be enabled with a bool `intervalCheck` prop, and added `intervalDelay` prop (which was the old `delay`) that can adjust the interval check.
Update: Updated tests to the new version and added test for user scrolling.
Update: intervalCheck is automatically enabled when `scrollCheck` props is set to `false`
Update: Readme to add the new props + descriptions
