### PR TITLE
added display and visibility checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-component",
     "visibility"
   ],
-  "author": "joshwnj",
+  "author": "Mole Wong <tszyeung@gmail.com",
   "license": "MIT",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -39,7 +39,9 @@ module.exports = React.createClass({
     intervalDelay: React.PropTypes.number,
     containment: containmentPropType,
     children: React.PropTypes.element,
-    minTopValue: React.PropTypes.number
+    minTopValue: React.PropTypes.number,
+    displayCheck: React.PropTypes.bool,
+    visibilityCheck: React.PropTypes.bool,
   },
 
   getDefaultProps: function () {
@@ -53,6 +55,8 @@ module.exports = React.createClass({
       intervalDelay: 1500,
       delayedCall: false,
       containment: null,
+      displayCheck: true,
+      visibilityCheck: true,
       children: React.createElement('span')
     };
   },
@@ -119,6 +123,16 @@ module.exports = React.createClass({
     // if the component has rendered to null, dont update visibility
     if (!el) {
       return this.state;
+    }
+
+    var elStyle = window.getComputedStyle(el);
+
+    if(this.props.displayCheck && elStyle.display === 'none') {
+        return false;
+    }
+
+    if(this.props.visibilityCheck && elStyle.display === 'none') {
+        return false;
     }
 
     rect = el.getBoundingClientRect();

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -131,7 +131,7 @@ module.exports = React.createClass({
         return false;
     }
 
-    if(this.props.visibilityCheck && elStyle.display === 'none') {
+    if(this.props.visibilityCheck && elStyle.visibility === 'hidden') {
         return false;
     }
 


### PR DESCRIPTION
## Display and visibility checks

- Added this props to the component
  1. `displayCheck` with type `bool`, and
  2. `visibilityCheck` with type `bool`.

- The two new props are set to true by default.

- Objective: when an element is not visible due to `display` or `visibility` properties, the sensor returns `false`
  1. if element's `display` property is `none`
    - return `false`,
    - else, return `true`;
  2. if element's `visibility` property is `hidden`
    - return `false`
    - else, return `true`;