### PR TITLE
Clear debounceCheck when deactivating

### DIFF
--- a/tests/visibility-sensor-spec.jsx
+++ b/tests/visibility-sensor-spec.jsx
@@ -134,4 +134,25 @@ describe('VisibilitySensor', function () {
 
     ReactDOM.render(element, node);
   });
+
+  it('should clear interval and debounceCheck when deactivated', function () {
+    var onChange = function () {};
+
+    var element1 = (
+      <VisibilitySensor active={true} onChange={onChange} scrollCheck />
+    );
+
+    var element2 = (
+      <VisibilitySensor active={false} onChange={onChange} scrollCheck />
+    );
+
+    var component1 = ReactDOM.render(element1, node);
+    assert(component1.interval, 'interval should be set');
+    assert(component1.debounceCheck, 'debounceCheck should be set');
+
+    var component2 = ReactDOM.render(element2, node);
+    assert(!component2.interval, 'interval should not be set');
+    assert(!component2.debounceCheck, 'debounceCheck should not be set');
+
+  });
 });

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -104,7 +104,10 @@ module.exports = React.createClass({
   },
 
   stopWatching: function () {
-    if (this.debounceCheck) { this.getContainer().removeEventListener('scroll', this.debounceCheck); }
+    if (this.debounceCheck) {
+      this.getContainer().removeEventListener('scroll', this.debounceCheck);
+      this.debounceCheck = null;
+    }
     if (this.interval) { this.interval = clearInterval(this.interval); }
   },
 


### PR DESCRIPTION
The VisibilitySensor doesn't get reactivated if `scrollCheck` is active. That's because `this.debounceCheck` is not cleared properly and still contains the debounced function after `stopWatching()` has run.

Under these circumstances, the following condition is true and `startWatching()` gets skipped:
```js
  startWatching: function () {
    if (this.debounceCheck || this.interval) { return; }
```