### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -2,9 +2,10 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom')
+var createReactClass = require('create-react-class')
 var VisibilitySensor = require('../');
 
-var Example = React.createClass({
+var Example = createReactClass({
   getInitialState: function () {
     return { msg: '' };
   },

--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
   "browserify-shim": {
     "react": "global:React",
     "react-dom": "global:ReactDOM"
+  },
+  "dependencies": {
+    "create-react-class": "^15.5.1",
+    "prop-types": "^15.5.4"
   }
 }

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -2,12 +2,14 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var isVisibleWithOffset = require('./lib/is-visible-with-offset')
 
-var containmentPropType = React.PropTypes.any;
+var containmentPropType = PropTypes.any;
 
 if (typeof window !== 'undefined') {
-  containmentPropType = React.PropTypes.instanceOf(window.Element);
+  containmentPropType = PropTypes.instanceOf(window.Element);
 }
 
 function throttle (callback, limit) {
@@ -36,41 +38,41 @@ function debounce(func, wait) {
   };
 }
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'VisibilitySensor',
 
   propTypes: {
-    onChange: React.PropTypes.func.isRequired,
-    active: React.PropTypes.bool,
-    partialVisibility: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+    onChange: PropTypes.func.isRequired,
+    active: PropTypes.bool,
+    partialVisibility: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
     ]),
-    delayedCall: React.PropTypes.bool,
-    offset: React.PropTypes.oneOfType([
-      React.PropTypes.shape({
-        top: React.PropTypes.number,
-        left: React.PropTypes.number,
-        bottom: React.PropTypes.number,
-        right: React.PropTypes.number
+    delayedCall: PropTypes.bool,
+    offset: PropTypes.oneOfType([
+      PropTypes.shape({
+        top: PropTypes.number,
+        left: PropTypes.number,
+        bottom: PropTypes.number,
+        right: PropTypes.number
       }),
       // deprecated offset property
-      React.PropTypes.shape({
-        direction: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
-        value: React.PropTypes.number
+      PropTypes.shape({
+        direction: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+        value: PropTypes.number
       })
     ]),
-    scrollCheck: React.PropTypes.bool,
-    scrollDelay: React.PropTypes.number,
-    scrollThrottle: React.PropTypes.number,
-    resizeCheck: React.PropTypes.bool,
-    resizeDelay: React.PropTypes.number,
-    resizeThrottle: React.PropTypes.number,
-    intervalCheck: React.PropTypes.bool,
-    intervalDelay: React.PropTypes.number,
+    scrollCheck: PropTypes.bool,
+    scrollDelay: PropTypes.number,
+    scrollThrottle: PropTypes.number,
+    resizeCheck: PropTypes.bool,
+    resizeDelay: PropTypes.number,
+    resizeThrottle: PropTypes.number,
+    intervalCheck: PropTypes.bool,
+    intervalDelay: PropTypes.number,
     containment: containmentPropType,
-    children: React.PropTypes.element,
-    minTopValue: React.PropTypes.number,
+    children: PropTypes.element,
+    minTopValue: PropTypes.number,
   },
 
   getDefaultProps: function () {


### PR DESCRIPTION
I think we should migrate to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people stop having deprecation warnings after migration to React v15.5. 

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.