### PR TITLE
allow passing a children function that takes state and chooses what to render from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ function render () {
 }
 ```
 
+You can also pass a child function, which can be convenient if you don't need to store the visibility anywhere:
+
+```js
+return (
+  <VisibilitySensor>
+    {({isVisible}) =>
+      <div>I am {isVisible ? 'visible' : 'invisible'}</div>
+    }
+  </VisibilitySensor>
+);
+```
 
 Props
 ----
@@ -66,6 +77,7 @@ Props
 - `resizeThrottle`: (default: `-1`) by specifying a value > -1, you are enabling throttle instead of the delay to trigger checks on resize event. Throttle supercedes delay.
 - `containment`: (optional) element to use as a viewport when checking visibility. Default behaviour is to use the browser window as viewport.
 - `delayedCall`: (default `false`) if is set to true, wont execute on page load ( prevents react apps triggering elements as visible before styles are loaded )
+- `children`: can be a React element or a function.  If you provide a function, it will be called with 1 argument `{isVisible: ?boolean, visibilityRect: Object}`
 
 It's possible to use both `intervalCheck` and `scrollCheck` together. This means you can detect most visibility changes quickly with `scrollCheck`, and an `intervalCheck` with a higher `intervalDelay` will act as a fallback for other visibility events, such as resize of a container.
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
     "mocha": "^1.21.4",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "reactify": "^1.1.1",
     "uglify-js": "^3.0.15"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
     "mocha": "^1.21.4",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0",
     "reactify": "^1.1.1",
     "uglify-js": "^3.0.15"
   },

--- a/tests/visibility-sensor-spec.jsx
+++ b/tests/visibility-sensor-spec.jsx
@@ -241,4 +241,24 @@ describe('VisibilitySensor', function () {
     ReactDOM.render(element, node);
   });
 
+  it('should call child function with state', function (done) {
+    var wasChildrenCalled = false;
+    var children = function (props) {
+      wasChildrenCalled = true;
+      assert('isVisible' in props, 'children should be called with isVisible prop');
+      assert('visibilityRect' in props, 'children should be called with visibilityRect prop');
+      return <div />;
+    };
+
+    setTimeout(function () {
+      assert(wasChildrenCalled, 'children should be called');
+      done();
+    }, 200);
+
+    var element = (
+      <VisibilitySensor>{children}</VisibilitySensor>
+    );
+
+    ReactDOM.render(element, node);
+  });
 });

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -71,7 +71,10 @@ module.exports = createReactClass({
     intervalCheck: PropTypes.bool,
     intervalDelay: PropTypes.number,
     containment: containmentPropType,
-    children: PropTypes.element,
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+    ]),
     minTopValue: PropTypes.number,
   },
 
@@ -310,6 +313,7 @@ module.exports = createReactClass({
   },
 
   render: function () {
+    if (this.props.children instanceof Function) return this.props.children(this.state);
     return React.Children.only(this.props.children);
   }
 });

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -42,7 +42,7 @@ module.exports = createReactClass({
   displayName: 'VisibilitySensor',
 
   propTypes: {
-    onChange: PropTypes.func.isRequired,
+    onChange: PropTypes.func,
     active: PropTypes.bool,
     partialVisibility: PropTypes.oneOfType([
       PropTypes.bool,
@@ -306,7 +306,7 @@ module.exports = createReactClass({
         visibilityRect: visibilityRect
       };
       this.setState(state);
-      this.props.onChange(isVisible, visibilityRect);
+      if (this.props.onChange) this.props.onChange(isVisible, visibilityRect);
     }
 
     return state;

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -313,7 +313,12 @@ module.exports = createReactClass({
   },
 
   render: function () {
-    if (this.props.children instanceof Function) return this.props.children(this.state);
+    if (this.props.children instanceof Function) {
+      return this.props.children({
+        isVisible: this.state.isVisible,
+        visibilityRect: this.state.visibilityRect,
+      });
+    }
     return React.Children.only(this.props.children);
   }
 });


### PR DESCRIPTION
This is the number one feature I've wanted in `react-visibility-sensor` for a long time.  It's a pattern I first saw in `react-motion` that I've really come to like.  I also got the creator of `react-measure` to add this pattern to his package.  Here's what it looks like:

```js
  <VisibilitySensor>
    {({isVisible}) =>
      <div>I am {isVisible ? 'visible' : 'invisible'}</div>
    }
  </VisibilitySensor>
```

This is super convenient if all you need to do is change what you render inside the component based upon whether it's visible, because you don't have to go to the trouble of storing the visibility state anywhere in your own code.

This PR doesn't cause any breaking changes; you can still use a React element for the children, and a children function can be used together with `onChange` or without it -- I made `onChange` optional.