### PR TITLE
update uglifyjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "reactify": "^1.1.1",
-    "uglifyjs": "^2.4.10"
+    "uglify-js": "^3.0.15"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To fix the CI issue:

```
npm WARN deprecated uglifyjs@2.4.11: uglifyjs is deprecated - use uglify-js instead.
```

(https://travis-ci.org/joshwnj/react-visibility-sensor/builds/240078147?utm_source=github_status)