### PR TITLE
Do not unnecessarily reset state; extra checks when component receive…

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -117,10 +117,10 @@ module.exports = createReactClass({
   },
 
   componentWillReceiveProps: function (nextProps) {
-    if (nextProps.active) {
+    if (nextProps.active && !this.props.active) {
       this.setState(this.getInitialState());
       this.startWatching();
-    } else {
+    } else if (!nextProps.active) {
       this.stopWatching();
     }
   },


### PR DESCRIPTION
…s props

Ran into an issue where React seemed to be rerendering the VisibilitySensor every time the parent component's state changed. Because nextProps had the active bool, VisibilitySensor's isVisible state was being set back to null and the onChange trigger was called saying the sensor was visible (even though it had already told the parent it was visible). 

This change proposes the component receiving new props check should be a little bit more explicit. Related to issue https://github.com/joshwnj/react-visibility-sensor/issues/78. 

Sorry there are no tests for this; I spent a little while trying to figure out a coherent test but I am used to testing with enzyme and couldn't come up with a great solution using just the assert module.