### PR TITLE
Adding scrollContainment property

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Props
 - `resizeDelay`: (default: `250`) is the debounce rate at which the check is triggered. Ex: 250ms after the user stopped resizing.
 - `resizeThrottle`: (default: `-1`) by specifying a value > -1, you are enabling throttle instead of the delay to trigger checks on resize event. Throttle supercedes delay.
 - `containment`: (optional) element to use as a viewport when checking visibility. Default behaviour is to use the browser window as viewport.
+- `scrollContainment`: (optional) element to use as a viewport when checking visibility when containment has overflow-y. Only needed when `containment` is not enough to catch visibility change.
 - `delayedCall`: (default `false`) if is set to true, wont execute on page load ( prevents react apps triggering elements as visible before styles are loaded )
 - `children`: can be a React element or a function.  If you provide a function, it will be called with 1 argument `{isVisible: ?boolean, visibilityRect: Object}`
 

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -83,6 +83,7 @@ module.exports = createReactClass({
     intervalCheck: PropTypes.bool,
     intervalDelay: PropTypes.number,
     containment: containmentPropType,
+    scrollContainment: containmentPropType,
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,
@@ -106,6 +107,7 @@ module.exports = createReactClass({
       delayedCall: false,
       offset: {},
       containment: null,
+      scrollContainment: null,
       children: React.createElement('span')
     };
   },
@@ -142,6 +144,10 @@ module.exports = createReactClass({
 
   getContainer: function () {
     return this.props.containment || window;
+  },
+
+  getScrollContainer: function () {
+      return this.props.scrollContainment || window;
   },
 
   addEventListener: function (target, event, delay, throttle) {
@@ -191,7 +197,7 @@ module.exports = createReactClass({
 
     if (this.props.scrollCheck) {
       this.addEventListener(
-        this.getContainer(),
+        this.getScrollContainer(),
         'scroll',
         this.props.scrollDelay,
         this.props.scrollThrottle

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -147,7 +147,7 @@ module.exports = createReactClass({
   },
 
   getScrollContainer: function () {
-      return this.props.scrollContainment || window;
+      return this.props.scrollContainment || this.getContainer();
   },
 
   addEventListener: function (target, event, delay, throttle) {


### PR DESCRIPTION
Hi,

I encountered a case where I need to assign the scroll container (div upstream with overflow-y) but keep the containment to window (otherwise check() with not see if my div was inside the viewport.

I therefore suggest adding the property as per my pullrequest. However, it might be a breaking change since the usage of containment is different. I think that could be solved by defaulting back to containment if scrollcontainment is not defined.

What do you think?