### PR TITLE
Pass the DOM element in onChange

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -306,7 +306,7 @@ module.exports = createReactClass({
         visibilityRect: visibilityRect
       };
       this.setState(state);
-      if (this.props.onChange) this.props.onChange(isVisible, visibilityRect);
+      if (this.props.onChange) this.props.onChange(isVisible, visibilityRect, el);
     }
 
     return state;


### PR DESCRIPTION
Pass the DOM element in onChange. Allows the ability to set data attributes and access them in onChange. Useful for lists. Could pass `this` instead, and/or remove visibilityRect and instead just pass the element, as visibilityRect is easily accessed from the element.

Need to update documentation as well.

Any thoughts?