### PR TITLE
Allow React 16 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "joshwnj",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "browserify": "^5.11.2",


### PR DESCRIPTION
Fixes #93 

I'm using this library without any issue in a large React 16 codebase. I think it's safe to simply allow 16 as a valid peerDependency.