### PR TITLE
Clarify scrollCheck vs intervalCheck defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Props
 - `partialVisibility`: (default `false`) consider element visible if only part of it is visible. Also possible values are - 'top', 'right', 'bottom', 'left' - in case it's needed to detect when one of these become visible explicitly.
 - `offset`: (default `{}`) with offset you can define amount of px from one side when the visibility should already change. So in example setting `offset={{top:10}}` means that the visibility changes hidden when there is less than 10px to top of the viewport. Offset works along with `partialVisibility`
 - `minTopValue`: (default `0`) consider element visible if only part of it is visible and a minimum amount of pixels could be set, so if at least 100px are in viewport, we mark element as visible.
-- `intervalCheck`: (default `true`) the default usage of Visibility Sensor is to trigger a check on user scrolling, by checking this as true, it gives you the possibility to check if the element is in view even if it wasn't because of a user scroll
+- `intervalCheck`: (default `true`) the default usage of Visibility Sensor is to trigger a check on an interval, by leaving this as true, it checks if the element is in view even if it wasn't because of a user scroll
 - `intervalDelay`: (default `1500`) integer, number of milliseconds between checking the element's position in relation the the window viewport. Making this number too low will have a negative impact on performance.
 - `scrollCheck`: (default: `false`) by making this true, the scroll listener is enabled.
 - `scrollDelay`: (default: `250`) is the debounce rate at which the check is triggered. Ex: 250ms after the user stopped scrolling.


### PR DESCRIPTION
The readme suggests that scrollCheck is on and intervalCheck is off, but its the opposite. Happy to rewrite text if there is a clearer way to say this.