### PR TITLE
Fix bug: failed to detect visibility changes

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -217,6 +217,15 @@ module.exports = createReactClass({
     if (this.interval) { this.interval = clearInterval(this.interval); }
   },
 
+  roundRectDown: function (rect) {
+    return {
+      top: Math.floor(rect.top),
+      left: Math.floor(rect.left),
+      bottom: Math.floor(rect.bottom),
+      right: Math.floor(rect.right),
+    };
+  },
+
   /**
    * Check if the element is within the visible viewport
    */
@@ -229,7 +238,7 @@ module.exports = createReactClass({
       return this.state;
     }
 
-    rect = el.getBoundingClientRect();
+    rect = this.roundRectDown(el.getBoundingClientRect());
 
     if (this.props.containment) {
       var containmentDOMRect = this.props.containment.getBoundingClientRect();


### PR DESCRIPTION
Fix bug for edge cases where the plugin fails to detect visibility changes

+ The viewport rectangle values are Integers, while the plugin's Element
boundaries are Floats. In some edge cases, the boundaries will always be
outside of the viewport.
+ I rounded down the boundaries to fix the issue.