### PR TITLE
Update lifecycle method for React 16.3

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -116,11 +116,11 @@ module.exports = createReactClass({
     this.stopWatching();
   },
 
-  componentWillReceiveProps: function (nextProps) {
-    if (nextProps.active && !this.props.active) {
+  componentDidUpdate: function(prevProps) {
+    if (this.props.active && !prevProps.active) {
       this.setState(this.getInitialState());
       this.startWatching();
-    } else if (!nextProps.active) {
+    } else if (!this.props.active) {
       this.stopWatching();
     }
   },


### PR DESCRIPTION
`componentWillReceiveProps` was deprecated in React 16.3.0, so I changed it to `componentDidUpdate`. See here for more information: https://reactjs.org/blog/2018/03/29/react-v-16-3.html.

Hopefully this is OK, let me know if I should change anything.