### PR TITLE
Fix bug: containment prop doesn't seem to work with position absolute frame #86

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -233,11 +233,15 @@ module.exports = createReactClass({
 
     if (this.props.containment) {
       var containmentDOMRect = this.props.containment.getBoundingClientRect();
+      // gets the absolute top/left coordinates of the containment element relative to the window   
+      const containerTop = containerDOMRect.top + window.scrollY;
+      const containerLeft = containerDOMRect.left + window.scrollX;
+      
       containmentRect = {
-        top: containmentDOMRect.top,
-        left: containmentDOMRect.left,
-        bottom: containmentDOMRect.bottom,
-        right: containmentDOMRect.right,
+        top: containerTop,
+        left: containerLeft,
+        bottom: containerTop + containmentDOMRect.height,
+        right: containerLeft + containmentDOMRect.width,
       }
     } else {
       containmentRect = {

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -234,8 +234,8 @@ module.exports = createReactClass({
     if (this.props.containment) {
       var containmentDOMRect = this.props.containment.getBoundingClientRect();
       // gets the absolute top/left coordinates of the containment element relative to the window   
-      const containerTop = containerDOMRect.top + window.scrollY;
-      const containerLeft = containerDOMRect.left + window.scrollX;
+      const containerTop = containmentDOMRect.top + window.scrollY;
+      const containerLeft = containmentDOMRect.left + window.scrollX;
       
       containmentRect = {
         top: containerTop,


### PR DESCRIPTION
Fixed containment to check coordinates by its absolute position rather than relative position to the viewport