### PR TITLE
Stipping PropTypes for production code causes an error

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -6,12 +6,6 @@ var PropTypes = require('prop-types');
 var createReactClass = require('create-react-class');
 var isVisibleWithOffset = require('./lib/is-visible-with-offset')
 
-var containmentPropType = PropTypes.any;
-
-if (typeof window !== 'undefined') {
-  containmentPropType = PropTypes.instanceOf(window.Element);
-}
-
 function throttle (callback, limit) {
     var wait = false;
     return function () {
@@ -82,7 +76,7 @@ module.exports = createReactClass({
     resizeThrottle: PropTypes.number,
     intervalCheck: PropTypes.bool,
     intervalDelay: PropTypes.number,
-    containment: containmentPropType,
+    containment: typeof window !== 'undefined' ? PropTypes.instanceOf(window.Element) : PropTypes.any,
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,


### PR DESCRIPTION
Hello. I'm using **babel-plugin-transform-react-remove-prop-types**. It removes all PropTypes from my production code.

```
// This guy is removed
var containmentPropType = PropTypes.any;

if (typeof window !== 'undefined') {
  // This guy throws an error due to lack of var statement
  containmentPropType = PropTypes.instanceOf(window.Element);
}
```

I suggest using ternary operator in propTypes collection like so:
```
containment: typeof window !== 'undefined' ? PropTypes.instanceOf(window.Element) : PropTypes.any,
```