### PR TITLE
Fix webpack config to work with next.js

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -17,8 +17,6 @@ function normalizeRect(rect) {
   return rect;
 }
 
-//let containmentPropType = typeof window !== 'undefined' ? PropTypes.instanceOf(window.Element) : PropTypes.any;
-
 export default class VisibilitySensor extends React.Component {
   static defaultProps = {
     active: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = env => {
       path: path.resolve(__dirname, "dist"),
       filename: "[name].js",
       library: "react-visibility-sensor",
-      libraryTarget: "umd"
+      libraryTarget: "umd",
+      globalObject: "this"
     };
   }
 


### PR DESCRIPTION
Fixes #139 

Following the advice from here: https://github.com/webpack/webpack/issues/6642

- set `output.globalObject` to `"this"`,  so next.js doesn't complain about window reference