### PR TITLE
Add option to detect visibility for contents with no width or height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-React Visibility Sensor
-====
+# React Visibility Sensor
 
 [![Build Status](https://secure.travis-ci.org/joshwnj/react-visibility-sensor.png)](http://travis-ci.org/joshwnj/react-visibility-sensor)
 
@@ -7,8 +6,7 @@ Sensor component for React that notifies you when it goes in or out of the windo
 
 Sponsored by [X-Team](https://x-team.com)
 
-Install
-----
+## Install
 
 `npm install react-visibility-sensor`
 
@@ -23,8 +21,7 @@ In this case, make sure that `React` and `ReactDOM` are already loaded and globa
 
 Take a look at the [umd example](./example-umd/) to see this in action
 
-Example
-----
+## Example
 
 [View an example on codesandbox](https://codesandbox.io/s/p73kyx9zpm)
 
@@ -40,13 +37,13 @@ To run the example locally:
 General usage goes something like:
 
 ```js
-const VisibilitySensor = require('react-visibility-sensor');
+const VisibilitySensor = require("react-visibility-sensor");
 
-function onChange (isVisible) {
-  console.log('Element is now %s', isVisible ? 'visible' : 'hidden');
+function onChange(isVisible) {
+  console.log("Element is now %s", isVisible ? "visible" : "hidden");
 }
 
-function MyComponent (props) {
+function MyComponent(props) {
   return (
     <VisibilitySensor onChange={onChange}>
       <div>...content goes here...</div>
@@ -58,22 +55,19 @@ function MyComponent (props) {
 You can also pass a child function, which can be convenient if you don't need to store the visibility anywhere:
 
 ```js
-function MyComponent (props) {
+function MyComponent(props) {
   return (
     <VisibilitySensor>
-      {({isVisible}) =>
-        <div>I am {isVisible ? 'visible' : 'invisible'}</div>
-      }
+      {({ isVisible }) => <div>I am {isVisible ? "visible" : "invisible"}</div>}
     </VisibilitySensor>
   );
 }
 ```
 
-Props
-----
+## Props
 
 - `onChange`: callback for whenever the element changes from being within the window viewport or not. Function is called with 1 argument `(isVisible: boolean)`
-- `active`: (default `true`) boolean flag for enabling / disabling the sensor.  When `active !== true` the sensor will not fire the `onChange` callback.
+- `active`: (default `true`) boolean flag for enabling / disabling the sensor. When `active !== true` the sensor will not fire the `onChange` callback.
 - `partialVisibility`: (default `false`) consider element visible if only part of it is visible. Also possible values are - 'top', 'right', 'bottom', 'left' - in case it's needed to detect when one of these become visible explicitly.
 - `offset`: (default `{}`) with offset you can define amount of px from one side when the visibility should already change. So in example setting `offset={{top:10}}` means that the visibility changes hidden when there is less than 10px to top of the viewport. Offset works along with `partialVisibility`
 - `minTopValue`: (default `0`) consider element visible if only part of it is visible and a minimum amount of pixels could be set, so if at least 100px are in viewport, we mark element as visible.
@@ -87,16 +81,15 @@ Props
 - `resizeThrottle`: (default: `-1`) by specifying a value > -1, you are enabling throttle instead of the delay to trigger checks on resize event. Throttle supercedes delay.
 - `containment`: (optional) element to use as a viewport when checking visibility. Default behaviour is to use the browser window as viewport.
 - `delayedCall`: (default `false`) if is set to true, wont execute on page load ( prevents react apps triggering elements as visible before styles are loaded )
-- `children`: can be a React element or a function.  If you provide a function, it will be called with 1 argument `{isVisible: ?boolean, visibilityRect: Object}`
+- `children`: can be a React element or a function. If you provide a function, it will be called with 1 argument `{isVisible: ?boolean, visibilityRect: Object}`
+- `requireContentsSize`: (default: `true`) whether the element should be required to have both width and height in order to be detected as visible. Making this to false can be useful for lazy loading solutions where you have an empty element which you only want to load contents into when it enters the viewport.
 
 It's possible to use both `intervalCheck` and `scrollCheck` together. This means you can detect most visibility changes quickly with `scrollCheck`, and an `intervalCheck` with a higher `intervalDelay` will act as a fallback for other visibility events, such as resize of a container.
 
-Thanks
-----
+## Thanks
 
 Special thanks to [contributors](https://github.com/joshwnj/react-visibility-sensor/graphs/contributors)
 
-License
-----
+## License
 
 MIT

--- a/tests/visibility-sensor-spec.jsx
+++ b/tests/visibility-sensor-spec.jsx
@@ -371,6 +371,24 @@ describe("VisibilitySensor", function() {
     ReactDOM.render(element, node);
   });
 
+  it("should return visible if the sensor has no size but contents size is not required", function(done){
+    var firstTime = true;
+    var onChange = function(isVisible) {
+      if (firstTime) {
+        assert.equal(isVisible, true, "Component is visible");
+        done();
+      }
+    };
+
+    var element = (
+      <VisibilitySensor onChange={onChange} requireContentsSize={false}>
+        <div style={{ height: "0px", width: "0px" }} />
+      </VisibilitySensor>
+    );
+
+    ReactDOM.render(element, node);
+  });
+
   it("should not return visible if the sensor is hidden", function(done) {
     var firstTime = true;
     var onChange = function(isVisible) {

--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -33,7 +33,8 @@ export default class VisibilitySensor extends React.Component {
     delayedCall: false,
     offset: {},
     containment: null,
-    children: <span />
+    children: <span />,
+    requireContentsSize: true
   };
 
   static propTypes = {
@@ -70,7 +71,8 @@ export default class VisibilitySensor extends React.Component {
         ? PropTypes.instanceOf(window.Element)
         : PropTypes.any,
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    minTopValue: PropTypes.number
+    minTopValue: PropTypes.number,
+    requireContentsSize: PropTypes.bool
   };
 
   constructor(props) {
@@ -268,15 +270,18 @@ export default class VisibilitySensor extends React.Component {
     // https://github.com/joshwnj/react-visibility-sensor/pull/114
     const hasSize = rect.height > 0 && rect.width > 0;
 
+    // Only register the rect as visible if it has size, unless requireContentsSize is false
+    const shouldDetectSize = hasSize || !this.props.requireContentsSize;
+
     let isVisible =
-      hasSize &&
+      shouldDetectSize &&
       visibilityRect.top &&
       visibilityRect.left &&
       visibilityRect.bottom &&
       visibilityRect.right;
 
     // check for partial visibility
-    if (hasSize && this.props.partialVisibility) {
+    if (shouldDetectSize && this.props.partialVisibility) {
       let partialVisible =
         rect.top <= containmentRect.bottom &&
         rect.bottom >= containmentRect.top &&


### PR DESCRIPTION
This PR would resolve [issue #155](https://github.com/joshwnj/react-visibility-sensor/issues/155)

**Changes:**
- Adds `requireContentsSize` prop which determines whether the sensor should be able to detect elements as visible even when they have no width or height

**Why:**
This resolves a problem introduced in pull request #114 which added a check that would prevent an element from being detected as visible if its client rect had no width and/or height. This was done for good reason - after all, this is a _visibility_ sensor and the element is clearly not visible.

However, this change causes some problems for people who are trying to use `react-visibility-sensor` for lazy loading/rendering solutions. I had a scenario where I had a component which I only wanted to render when it entered or got near the viewport - otherwise, I would just render an empty div in its place. I ended up being forced to apply a style of `min-height: 1px` to the div to make it work, which is okay, but it's messy and that behavior felt unintuitive and unexpected to me until I actually dug into the source code to figure out what was happening. This new `requireContentsSize` prop helps both by making it more clear that contents without width or height will not be detected by default and providing developers with an option to disable that behavior if they need to.