### PR TITLE
Ensure rect is rounded correctly

### DIFF
--- a/visibility-sensor.js
+++ b/visibility-sensor.js
@@ -208,8 +208,8 @@ export default class VisibilitySensor extends React.Component {
 
   roundRectDown(rect) {
     return {
-      top: Math.floor(rect.top),
-      left: Math.floor(rect.left),
+      top: Math.ceil(rect.top),
+      left: Math.ceil(rect.left),
       bottom: Math.floor(rect.bottom),
       right: Math.floor(rect.right)
     };


### PR DESCRIPTION
This fixes a bug introduced in #116, which introduced rounding on the element rect. When a `containment` is specified that itself has non-integer values in its bounding rect, you get a rounding issue as `top` and `left` will be floored, causing them to go out of the containment bounding rect.
Say you have a container element with `left: 100.5` and the element rect at `left: 100.5` as well; this then gets rounded down to `left: 100`, meaning it is no longer considered completely visible.