### PR TITLE
Export Props Interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare module "react-visibility-sensor" {
     right?: number;
   }
 
-  interface Props {
+  export interface ReactVisibilitySensorProps {
     onChange?: (isVisible: boolean) => void;
     active?: boolean;
     partialVisibility?: boolean;
@@ -31,7 +31,7 @@ declare module "react-visibility-sensor" {
         ) => React.ReactNode);
   }
 
-  const ReactVisibilitySensor: React.StatelessComponent<Props>;
+  const ReactVisibilitySensor: React.StatelessComponent<ReactVisibilitySensorProps>;
 
   export default ReactVisibilitySensor;
 }


### PR DESCRIPTION
Hello,

It's great that you guys thought of TS users and created an index.d.ts file so that it can hook right in! However, the Props interface for ReactVisibilitySensor is not being exported, which makes it difficult for one to extend without just copying and pasting. This PR rectifies that by adding an export and renaming the interface to something less generic.