### PR TITLE
Update types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module "react-visibility-sensor" {
         ) => React.ReactNode);
   }
 
-  const ReactVisibilitySensor: React.StatelessComponent<Props>;
+  const ReactVisibilitySensor: React.ComponentType<Props>;
 
   export default ReactVisibilitySensor;
 }


### PR DESCRIPTION
# Description

The current types trigger an error:
```
node_modules/react-visibility-sensor/index.d.ts:34:38 - error TS2694: Namespace 'React' has no exported member 'StatelessComponent'.

34   const ReactVisibilitySensor: React.StatelessComponent<Props>;
                                        ~~~~~~~~~~~~~~~~~~
```

Indeed, `React.StatelessComponent` has been removed from the react types (see https://stackoverflow.com/questions/44375759/how-should-i-declare-a-stateless-functional-component-with-typescript-in-react)

This PR fixes this error.