### PR TITLE
React.StatelessComponent => React.FC

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module "react-visibility-sensor" {
         ) => React.ReactNode);
   }
 
-  const ReactVisibilitySensor: React.StatelessComponent<Props>;
+  const ReactVisibilitySensor: React.FC<Props>;
 
   export default ReactVisibilitySensor;
 }


### PR DESCRIPTION
Hello Josh Johnston,

I have proposed a change in the React component types in your library, switching from React.StatelessComponent to React.FC. This change was made for the following reasons:

Deprecation of React.StatelessComponent: As of React 16.8, the alias React.StatelessComponent has been deprecated. This is because React no longer strictly divides components into "stateful" and "stateless" ones. Instead, all components can now use hooks, making the distinction between StatelessComponent and Component less significant.

Transition to React.FC: 
React.FC or React.FunctionComponent provides clearer and more modern conventions for defining functional components. It includes proper default children definitions, and allows for the use of propTypes and defaultProps in a typed manner.
These changes make the code cleaner and more maintainable, and also enhance compatibility with current and future versions of React. I would appreciate it if you consider this change for inclusion in the main branch of your project.

Best regards,
Anton Fedorovskyi